### PR TITLE
Add SonarQube integration to the project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
       - run: npm install
       - run: npm test
       - run: node ci-analysis.js
-          env:
-            SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}
+        env:
+          SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,3 @@ jobs:
       - run: npm test
         env:
           SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}
-      - run: node ci-analysis.js
-        env:
-          SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: push
 
 jobs:
   test:
@@ -16,3 +12,6 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm test
+      - run: node ci-analysis.js
+          env:
+            SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm test
+        env:
+          SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}
       - run: node ci-analysis.js
         env:
           SONAR_AUTH_TOKEN: ${{secrets.SONAR_AUTH_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ HIFIS Marketplace
 ![](https://github.com/hifis-cloud/hifis-marketplace/workflows/CI/badge.svg)
 
 An entry point web application for scientific related services from various vendors.
+
+### Running the CI in your fork
+
+If you want to run the SonarQube tests in your fork, you will have to create a GitHub secret with the name `SONAR_AUTH_TOKEN` in your repository. You can get the necessary token in SonarQube via "My Account" -> "Security" -> "Tokens".

--- a/ci-analysis.js
+++ b/ci-analysis.js
@@ -7,6 +7,13 @@ sonarqubeScanner(
     options: {
       'sonar.projectKey': 'hifis-ui',
       'sonar.sources': 'src',
+      'sonar.projectVersion': '0.0.1',
+      'sonar.language': 'js',
+      'sonar.sourceEncoding': 'UTF-8',
+      'sonar.exclusions': 'src/**/*.spec.js',
+      'sonar.test.inclusions': 'src/**/*.spec.js',
+      'sonar.coverage.exclusions':
+        'src/**/*.spec.js,src/**/*.mock.js,node_modules/*,coverage/lcov-report/*',
     },
   },
   () => process.exit(),

--- a/ci-analysis.js
+++ b/ci-analysis.js
@@ -1,0 +1,13 @@
+const sonarqubeScanner = require('sonarqube-scanner'); // eslint-disable-line import/no-extraneous-dependencies
+
+sonarqubeScanner(
+  {
+    serverUrl: 'https://sonar.desy.de',
+    token: process.env.SONAR_AUTH_TOKEN,
+    options: {
+      'sonar.projectKey': 'hifis-ui',
+      'sonar.sources': 'src',
+    },
+  },
+  () => process.exit(),
+);

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "karma start",
     "test:coverage": "karma start --coverage",
     "test:watch": "karma start --auto-watch=true --single-run=false",
-    "start": "es-dev-server --app-index index.html --node-resolve --open --watch",
-    "posttest": "node ci-analysis.js"
+    "test:post": "node ci-analysis.js",
+    "start": "es-dev-server --app-index index.html --node-resolve --open --watch"
   },
   "devDependencies": {
     "eslint": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "karma start",
     "test:coverage": "karma start --coverage",
     "test:watch": "karma start --auto-watch=true --single-run=false",
-    "start": "es-dev-server --app-index index.html --node-resolve --open --watch"
+    "start": "es-dev-server --app-index index.html --node-resolve --open --watch",
+    "posttest": "node ci-analysis.js"
   },
   "devDependencies": {
     "eslint": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "karma start",
     "test:coverage": "karma start --coverage",
     "test:watch": "karma start --auto-watch=true --single-run=false",
-    "test:post": "node ci-analysis.js",
+    "posttest": "node ci-analysis.js",
     "start": "es-dev-server --app-index index.html --node-resolve --open --watch"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@open-wc/testing-karma": "^3.0.0",
     "deepmerge": "^3.2.0",
     "@open-wc/testing": "^2.0.0",
-    "es-dev-server": "^1.5.0"
+    "es-dev-server": "^1.5.0",
+    "sonarqube-scanner": "^2.6.0"
   },
   "eslintConfig": {
     "extends": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.projectVersion=0.0.1
-sonar.language=js
-sonar.sourceEncoding=UTF-8
-sonar.exclusions=src/**/*.spec.js
-sonar.test.inclusions=src/**/*.spec.js
-sonar.coverage.exclusions=src/**/*.spec.js,src/**/*.mock.js,node_modules/*,coverage/lcov-report/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.host.url=https://sonar.desy.de
+sonar.projectVersion=0.0.1
+sonar.language=js
+sonar.sources=src
+sonar.sourceEncoding=UTF-8
+sonar.exclusions=src/**/*.spec.js
+sonar.test.inclusions=src/**/*.spec.js
+sonar.coverage.exclusions=src/**/*.spec.js,src/**/*.mock.js,node_modules/*,coverage/lcov-report/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,5 @@
-sonar.host.url=https://sonar.desy.de
 sonar.projectVersion=0.0.1
 sonar.language=js
-sonar.sources=src
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=src/**/*.spec.js
 sonar.test.inclusions=src/**/*.spec.js


### PR DESCRIPTION
**Motivation:**

* automatically execute checks with SonarQube after each commit in CI

**Modification:**

* modified package.json to execute checks and added the necessary configuration

**Result:**

* SonarQubeChecks are executed automatically

**Additional Remarks:**

This is a new PR after cleaning up my fork and adressing the changes requested in PR #2 (https://github.com/helmholtz-marketplace/helmholtz-marketplace-webapp/pull/2). In detail, I changed the following:

* moved SonarQube access token to a environment variable which is created from a Github secret (see `README.md` for this)
* limited changes in `package.json` to the single added line `"sonarqube-scanner": "^2.6.0"`

I did not change the script in `package.json` starting with `"posttest"` this is valid according to the docs and I tried using `"test:post` which is not executed. 

The comment on the first line in `ci-analysis.js` is necessary, because otherwise eslint complains about extraneous dependencies.
