### PR TITLE
rename Sonar project to be consistent with the rest of the project

### DIFF
--- a/ci-analysis.js
+++ b/ci-analysis.js
@@ -5,7 +5,8 @@ sonarqubeScanner(
     serverUrl: 'https://sonar.desy.de',
     token: process.env.SONAR_AUTH_TOKEN,
     options: {
-      'sonar.projectKey': 'hifis-ui',
+      'sonar.projectKey': 'de.helmholtz.marketplace.hifis-marketplace',
+      'sonar.projectName': 'Helmholtz Marketplace Web App',
       'sonar.sources': 'src',
       'sonar.projectVersion': '0.0.1',
       'sonar.language': 'js',


### PR DESCRIPTION
Motivation:

Initially, this project is named HIFIS marketplace however
HIFIS is just one of the incubators belonging to the Helmholtz
associate. Hence, we replace the hifis name with helmholtz; to
reflect the project core objective and the association it belong.

Modification:

change the SonarQube configuration to reflect the change from PR4 (https://github.com/helmholtz-marketplace/helmholtz-marketplace-webapp/pull/4)

Result:

No visible changes to the end-user
The SonarQube project has now a project name and project key according to the other changes
