### PR TITLE
ci: add build and move sonarqube test

### DIFF
--- a/.github/workflows/build-and-sonarqube.yml
+++ b/.github/workflows/build-and-sonarqube.yml
@@ -1,0 +1,25 @@
+name: Build & Sonarqube
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm run test:sonarqube

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "test": "karma start",
         "test:coverage": "karma start --coverage",
         "test:watch": "karma start --auto-watch=true --single-run=false",
-        "posttest": "node ci-analysis.js",
+        "test:sonarqube": "node ci-analysis.js",
         "build": "rimraf target && rollup -c rollup.config.js",
         "start": "es-dev-server --app-index index.html --node-resolve --open --watch",
         "start:build": "npm run build && es-dev-server --root-dir target --app-index index.html --open --compatibility none"


### PR DESCRIPTION
Motivation:

When a pull request is created, the ci github action
always failed. This defeat the whole point of a ci.

Modification:

- add a github action that will be trigger only on a
    push to the master branch
- add a test for a build that will generate files that
    will later be used for creating an artifact
- move the sonarqube scanner from post test command to
    `test:sonarqube`

Result:

- no more build fail cause by sonarqube when a pull
    request created
- test for build is added and run
- test for sonarqube is run only when on a push
    request

Pull-request: #8